### PR TITLE
Release version 0.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clangd/install",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Installing clangd binaries from editor plugins.",
   "main": "out/src/index.js",
   "files": [


### PR DESCRIPTION
We need to release a new version so that vscode-clangd and coc-clangd can use https://github.com/clangd/node-clangd/pull/27 

